### PR TITLE
Fixed upper arms joint limits in the template

### DIFF
--- a/code/models/humanModelTemplate/humanModelTemplate.urdf
+++ b/code/models/humanModelTemplate/humanModelTemplate.urdf
@@ -1026,7 +1026,7 @@
         <parent link="RightShoulder"/>
         <child link="RightShoulder_f1"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.8727" upper="0.8727" />
+        <limit effort="30" velocity="1.0" lower="-2.35619" upper="1.5708" />
         <axis xyz="1 0 0" />
     </joint>
 	<joint name="jRightShoulder_roty" type="revolute">
@@ -1034,7 +1034,7 @@
         <parent link="RightShoulder_f1"/>
         <child link="RightShoulder_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.8727" upper="0.8727" />
+        <limit effort="30" velocity="1.0" lower="-1.5708" upper="1.5708" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightShoulder_rotz" type="revolute">
@@ -1042,7 +1042,7 @@
         <parent link="RightShoulder_f2"/>
         <child link="RightUpperArm"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.8727" upper="0.8727" />
+        <limit effort="30" velocity="1.0" lower="-0.785398" upper="3.14159" />
         <axis xyz="0 0 1" />
     </joint>
 ##############################################################################
@@ -1103,7 +1103,7 @@
         <parent link="LeftShoulder"/>
         <child link="LeftShoulder_f1"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.8727" upper="0.8727" />
+        <limit effort="30" velocity="1.0" lower="-1.5708" upper="2.35619" />
         <axis xyz="1 0 0" />
     </joint>
 	<joint name="jLeftShoulder_roty" type="revolute">
@@ -1111,7 +1111,7 @@
         <parent link="LeftShoulder_f1"/>
         <child link="LeftShoulder_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.8727" upper="0.8727" />
+        <limit effort="30" velocity="1.0" lower="-1.5708" upper="1.5708" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftShoulder_rotz" type="revolute">
@@ -1119,7 +1119,7 @@
         <parent link="LeftShoulder_f2"/>
         <child link="LeftUpperArm"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.8727" upper="0.8727" />
+        <limit effort="30" velocity="1.0" lower="-3.14159" upper="0.785398" />
         <axis xyz="0 0 1" />
     </joint>
 ##############################################################################


### PR DESCRIPTION
The joint limits in the template for the upper arms (i.e., jRightShoulder_rotx, jRightShoulder_roty, jRightShoulder_rotz, jLeftShoulder_rotx, jLeftShoulder_roty, jLeftShoulder_rotz) were not consistent with the limits in the human-gazebo models.  All the other joints limits were perfectly comparable.