### PR TITLE
Cleanup installation documentation after urchin fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This library requires the following dependencies:
 Create and activate a brand new enviroment with the required dependencies:
 ```
 conda create -n hmgenv python numpy urchin idyntree urdf-modifiers
-conda activate hgmenv
+conda activate hmgenv
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Therefore, the goal of the HMG is to develop an advanced human model that integr
 ## Dependencies 
 This library requires the following dependencies:
 
+- [``numpy``](https://github.com/numpy/numpy)
+- [``urchin``](https://github.com/fishbotics/urchin)
 - [``idyntree``](https://github.com/robotology/idyntree)
 - [``urdf-modifiers``](https://github.com/icub-tech-iit/urdf-modifiers)
 
@@ -25,7 +27,7 @@ This library requires the following dependencies:
 
 Create and activate a brand new enviroment with the required dependencies:
 ```
-conda create -n hmgenv idyntree urdf-modifiers
+conda create -n hmgenv python numpy urchin idyntree urdf-modifiers
 conda activate hgmenv
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,28 +20,13 @@ This library requires the following dependencies:
 
 - [``idyntree``](https://github.com/robotology/idyntree)
 - [``urdf-modifiers``](https://github.com/icub-tech-iit/urdf-modifiers)
-- [``urchin``](https://github.com/fishbotics/urchin.git) *(Note: the usage of `urchin` is a temporary step. Once the branch (`traversaro-patch-2`) is merged, it will be integrated into `urdf-modifiers`.)
 
 ## Installation with [conda](https://docs.conda.io/en/latest/) (recommended)
 
-- Create and activate a brand new enviroment
+Create and activate a brand new enviroment with the required dependencies:
 ```
-conda create -n name_new_env
-conda activate name_new_env
-```
-- Install `idyntree` following [these instructions](https://github.com/robotology/idyntree?tab=readme-ov-file#conda-recommended) [MATLAB bindings not required]
-- Install `urdf-modifiers`
-```
-git clone https://github.com/icub-tech-iit/urdf-modifiers.git
-cd urdf-modifiers
-pip install .
-```
-- Install `urchin`
-```
-git clone https://github.com/fishbotics/urchin.git
-cd urchin
-git checkout traversaro-patch-2
-pip install .
+conda create -n hmgenv idyntree urdf-modifiers
+conda activate hgmenv
 ```
 
 ## Usage


### PR DESCRIPTION
The urchin fix https://github.com/fishbotics/urchin/pull/22 was finally released in urchin 0.0.29 on both PyPI (https://github.com/fishbotics/urchin/issues/24) and conda-forge (https://github.com/conda-forge/urchin-feedstock/pull/1), so we can just install the dependencies normally (for example via conda) and everything will work. Furthermore, I also mention `numpy` as a dependency as it is a dependency of the script.

Fix https://github.com/ami-iit/human-model-generator/issues/21 .